### PR TITLE
Disable strict mode

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -3,7 +3,7 @@ var handler = function (compileStep, isLiterate) {
 
   var source = compileStep.read().toString('utf8');
   var outputFile = compileStep.inputPath + ".js";
-  var to5output = to5.transform(source, { sourceMap: true });
+  var to5output = to5.transform(source, { blacklist: ["useStrict"], sourceMap: true });
 
   compileStep.addJavaScript({
     path: outputFile,


### PR DESCRIPTION
This change disables `"use strict"` in transformed files. Without that, it is necessary to use:

``` javascript
var global = (0, eval)('this');

global.SomeObject = {};
```

instead of just:

``` javascript
SomeObject = {};
```

which is de facto how variables are shared in Meteor by default.
