### PR TITLE
set the filename correctly on the sourcemap

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -3,7 +3,8 @@ var handler = function (compileStep, isLiterate) {
 
   var source = compileStep.read().toString('utf8');
   var outputFile = compileStep.inputPath + ".js";
-  var to5output = to5.transform(source, { blacklist: ["useStrict"], sourceMap: true });
+  var to5output = to5.transform(source, { blacklist: ["useStrict"], sourceMap: true,
+    filename:compileStep.pathForSourceMap });
 
   compileStep.addJavaScript({
     path: outputFile,


### PR DESCRIPTION
This is really useful if you're using es6 code inside meteor packages as I am and you want to debug on the client.
