### PR TITLE
Stringify source map when calling compileStep.addJavaScript.

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -1,16 +1,19 @@
 var to5 = Npm.require('babel-core');
 var handler = function (compileStep, isLiterate) {
-
   var source = compileStep.read().toString('utf8');
   var outputFile = compileStep.inputPath + ".js";
-  var to5output = to5.transform(source, { blacklist: ["useStrict"], sourceMap: true,
-    filename:compileStep.pathForSourceMap });
+
+  var to5output = to5.transform(source, {
+    blacklist: ["useStrict"],
+    sourceMap: true,
+    filename: compileStep.pathForSourceMap
+  });
 
   compileStep.addJavaScript({
     path: outputFile,
     sourcePath: compileStep.inputPath,
     data: to5output.code,
-    sourceMap: to5output.map
+    sourceMap: JSON.stringify(to5output.map)
   });
 };
 


### PR DESCRIPTION
This is unfortunately necessary because `convertSourceMapPaths` calls `JSON.parse` unconditionally: https://github.com/meteor/meteor/blob/c4be008a70/tools/compiler.js#L333
