### PR TITLE
Bring back JSX processing

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -21,5 +21,4 @@ var handler = function (compileStep, isLiterate) {
 Plugin.registerSourceHandler('es6.js', handler);
 Plugin.registerSourceHandler('es6', handler);
 Plugin.registerSourceHandler('es', handler);
-// see: use react-tools instead https://github.com/grigio/meteor-babel/issues/10
-// Plugin.registerSourceHandler('jsx', handler);
+Plugin.registerSourceHandler('jsx', handler);


### PR DESCRIPTION
Not every use case of using JSX and React with Meteor warrants using the `reactjs:react` package. That package encompasses a lot of concerns that can be uncoupled -- loading React, the JSX compiler, and some React mixins. Those can be decoupled to provide better modularity, of which processing JSX files with this package is one example.

I released the [`grove:react`](https://github.com/grovelabs/meteor-react) package today that does just that. Obviously I'm biased, but I think it's a more flexible and powerful way of using React and Meteor together. I would love to be able to use this package for its JSX compilation capability - I may have even preemptively recommended it on the README :sweat_smile:  

Looking forward to your thoughts,

Louis
