### PR TITLE
Windows support.

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -47,7 +47,8 @@ var handler = function (compileStep, isLiterate) {
 };
 
 // initialization once at `meteor` exec
-var appdir = process.env.PWD;
+var appdir = process.env.PWD || process.cwd();
+console.log('App dit: ' + appdir);
 var filename = path.join(appdir,'babel.json');
 var userConfig = {};
 

--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -48,7 +48,6 @@ var handler = function (compileStep, isLiterate) {
 
 // initialization once at `meteor` exec
 var appdir = process.env.PWD || process.cwd();
-console.log('App dit: ' + appdir);
 var filename = path.join(appdir,'babel.json');
 var userConfig = {};
 


### PR DESCRIPTION
Hi,

Process.env.PWD does not work on windows. On windows we should use process.cwd().

Please review it and merge to master.

Best regards, Oleg!
