### PR TITLE
Display correct Meteor errors

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -29,9 +29,8 @@ var handler = function (compileStep, isLiterate) {
       filename: compileStep.pathForSourceMap
     });
   } catch (e) {
-    console.log(e); // Show the nicely styled babel error
     return compileStep.error({
-      message: 'Babel transform error',
+      message: e + "\n" + e.codeFrame,
       sourcePath: compileStep.inputPath,
       line: e.loc.line,
       column: e.loc.column


### PR DESCRIPTION
Babel errors now throw strings. Instead of console logging the errors, we can now print the error straight in the compileStep.error.
