### PR TITLE
Added option to pass trough compiler settings.

### DIFF
--- a/plugin/compile-6to5.js
+++ b/plugin/compile-6to5.js
@@ -22,12 +22,13 @@ var handler = function (compileStep, isLiterate) {
   var to5output = "";
 
   try {
-    to5output = to5.transform(source, {
+    var options = config.options || {};
+    to5output = to5.transform(source, Object.merge({
       blacklist: ["useStrict"],
       sourceMap: true,
       stage: config.stage,
       filename: compileStep.pathForSourceMap
-    });
+    }, options));
   } catch (e) {
     return compileStep.error({
       message: e + "\n" + e.codeFrame,


### PR DESCRIPTION
This PR allows us to provide options to the compiler. This is for example required if one wishes to provide support for class inheritance in IE10 or lower. See [protoToAssign](http://babeljs.io/docs/advanced/caveats/)

With this PR, placing a `babel.json` file with the following contents:

``` json
{
  "debug": true,
  "options": {
    "optional": ["spec.protoToAssign"]
  }
}
```

is equal to running

``` bash
 babel --optional spec.protoToAssign script.js
```

Compiler settings should be in the `options` key, to be defensive to `meteor-babel` conflicts. For example, the `debug` key, is for meteor-babel (this package) not for the actual compiler. So we shouldn't pass that along.
