### PR TITLE
fix symbol iterator bug for ios

### DIFF
--- a/lib/core-js-no-number.js
+++ b/lib/core-js-no-number.js
@@ -201,7 +201,7 @@ var $                 = require('./$')
   , invoke            = require('./$.invoke')
 // Safari has byggy iterators w/o `next`
   , BUGGY             = 'keys' in [] && !('next' in [].keys())
-  , SYMBOL_ITERATOR   = require('./$.wks')('iterator')
+  , SYMBOL_ITERATOR   = require('./$.wks')('iterator') || Symbol.iterator
   , FF_ITERATOR       = '@@iterator'
   , Iterators         = {}
   , IteratorPrototype = {};
@@ -1057,6 +1057,7 @@ function getCollection(NAME, methods, commonMethods, isMap, isWeak){
       done = true;
       return step(1);
     }};
+    var SYMBOL_ITERATOR=SYMBOL_ITERATOR || Symbol.iterator;
     O[SYMBOL_ITERATOR] = $.that;
     try { new C(O) } catch(e){}
     return done;

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'grigio:babel',
   summary: 'Write javascript ES6 in your Meteor app',
-  version: '0.1.7',
+  version: '0.1.8',
   git: 'https://github.com/grigio/meteor-babel.git'
 });
 


### PR DESCRIPTION
Hi @grigio 

to be honest i consider this as a dirty fix. As i cant really tell what is happening in iOS but it seems that the Symbol - Symbol.Iterator exists inside the webview and works the same way. So this PR falls back to this if it does not exists. I think the other chagnes are because MAC line endings ? Could find a way to fix this very fast. 
